### PR TITLE
fix: Update all entity attributes when configuring an entity

### DIFF
--- a/ucapi_framework/driver.py
+++ b/ucapi_framework/driver.py
@@ -541,13 +541,12 @@ class BaseIntegrationDriver(Generic[DeviceT, ConfigT]):
             try:
                 # Check if it's a dataclass - if so, entity.update() handles it
                 if is_dataclass(device_attrs):
-                    framework_entity.update(device_attrs, True)
+                    framework_entity.update(device_attrs, force=True)
                     return
                 # If it's a dict, use update_attributes directly
                 elif isinstance(device_attrs, dict):
                     framework_entity.update_attributes(
-                        cast(dict[str, Any], device_attrs),
-                        True
+                        cast(dict[str, Any], device_attrs), force=True
                     )
                     return
             except (TypeError, AttributeError) as e:


### PR DESCRIPTION
Version 1.5.0 of the ucapi-framework introduced the attribute filtering logic (resp. change detection, so that no unnecessary changes get published to the remote), which works really great.

But there seems to be a small catch:
1. Entity-Attributes-Update will be ignored by the `ucapi`, as long as an entity is available (i.e. NOT configured)
2. `Device.get_device_attributes()` gets still called within `refresh_entity_state` --> that's good! :)
3. If there is an Entity which is based on the newly introduced ucapi-framework-Entity-ABC, these attributes will flow through `entity.update()` resp. `entity.update_attributes()`, which ultimately call `entity.filter_changed_attributes`

This can be problematic for devices which take some time to be "fully operational" (e.g. for devices where the `sound_mode_list` is static` but the `source_list` dynamic, this):
1. There the `sound_mode_list` "change" gets emitted as part of the initial Device-Update-Event, where the entity is still only "available"
2. When configuring such an entity (because of the now established device connection), only the `source_list` gets transferred again to the Remote, leaving the `sound_mode_list` empty.

This PR changes the `BaseIntegrationDriver.refresh_entity_state()`-method in a way, so that it doesn't do the entity-attribute-filtering.